### PR TITLE
Add Linux setup script and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🛠️ UtilsMac
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 
-Colección personal de **scripts**, **dotfiles** y **configuraciones** para instalar, configurar y mantener un Mac de manera rápida y profesional.  
+Colección personal de **scripts**, **dotfiles** y **configuraciones** para preparar equipos Mac y Linux de manera rápida y profesional.
 Ideal para **reinstalaciones limpias**, **nuevos equipos** o simplemente para mejorar tu flujo de trabajo diario.
 
 ---
@@ -24,7 +24,21 @@ Ideal para **reinstalaciones limpias**, **nuevos equipos** o simplemente para me
 
 ```bash
 git clone https://github.com/guillecampoy/UtilsMac.git
-cd UtilsMac/scripts 
+cd UtilsMac
+```
+
+### 2. MacOS
+
+```bash
+cd scripts
+./setup_mac.sh
+```
+
+### 3. Pop!_OS (o derivados Debian)
+
+```bash
+cd scripts
+./setup_linux.sh
 ```
 
 ## 📄 Licencia
@@ -49,6 +63,12 @@ Si no tenés `gh` instalado, podés instalarlo en MacOS vía Homebrew:
 ```bash
 brew install gh
 ```
+
+## ✏️ Editor por defecto
+
+El setup fija **VSCode** como editor general del sistema. Para Git se mantiene
+un editor de consola (nano), por lo que al editar un commit se abrirá en la
+terminal.
 
 >**UtilsMac** nació entre terminales, scripts y buenos mates, para que cada equipo nuevo esté listo en minutos.  
 Código libre, espíritu libre. 🚀🧉

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Iniciando configuración de Pop!_OS..."
+
+# Actualizar e instalar paquetes base
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl wget apt-transport-https ca-certificates \
+    gnupg software-properties-common python3 python3-pip
+
+# VSCode
+if ! command -v code >/dev/null; then
+    echo "⚙️  Instalando Visual Studio Code..."
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | \
+        sudo tee /usr/share/keyrings/packages.microsoft.gpg > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/packages.microsoft.gpg] \
+        https://packages.microsoft.com/repos/code stable main" | \
+        sudo tee /etc/apt/sources.list.d/vscode.list
+    sudo apt update
+    sudo apt install -y code
+fi
+
+# KeepassXC y Syncthing
+sudo apt install -y keepassxc syncthing
+
+# Docker
+sudo apt install -y docker.io docker-compose
+sudo systemctl enable --now docker
+
+# sdkman y Java
+if [ ! -d "$HOME/.sdkman" ]; then
+    curl -s "https://get.sdkman.io" | bash
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+else
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+fi
+sdk install java
+
+# Spotify
+curl -sS https://download.spotify.com/debian/pubkey_0D811D58.gpg | sudo gpg --dearmor -o /usr/share/keyrings/spotify.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/spotify.gpg] \
+    http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
+sudo apt update
+sudo apt install -y spotify-client
+
+# Extras opcionales
+sudo apt install -y gnome-tweaks flameshot gimp obs-studio
+
+# Editor por defecto del sistema
+sudo update-alternatives --set editor /usr/bin/code
+
+# Editor de Git en consola
+git config --global core.editor "nano"
+
+echo "🎉 Configuración de Pop!_OS completada."


### PR DESCRIPTION
## Summary
- add a setup script for Pop!_OS with VSCode, Docker, sdkman, Spotify and more
- document Linux setup instructions and default editor behaviour in README

## Testing
- `bash -n scripts/setup_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c1e0072d083309985c9f0c342f027